### PR TITLE
Create basic organization setup module

### DIFF
--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -47,7 +47,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_account"></a> [iam\_account](#module\_iam\_account) | terraform-aws-modules/iam/aws//modules/iam-account | 5.46.0 |
+| <a name="module_iam_account"></a> [iam\_account](#module\_iam\_account) | terraform-aws-modules/iam/aws//modules/iam-account | ~>5.46.0 |
 
 ## Resources
 

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -1,0 +1,73 @@
+# AWS organization setup
+
+Basic module for setting up the organization. It includes:
+* IAM profile & password policy
+* Creating sub-accounts in org structure
+
+
+## Sub-accounts
+
+You can order sub-accounts by providing friendly name & email (needs to be unique per account)
+
+*Example:*
+```
+sub_accounts = {
+    dev     = "contact+dev@letsgodevops.pl"
+    sandbox = "contact+sandbox@letsgodevops.pl"
+    prod    = "contact+prod@letsgodevops.pl"
+}
+```
+
+Output provides map of all account in the organization (including reference to "main").
+This way you can use reference account id in friendly way:
+```
+module.org.accounts["main"].id
+```
+You can also specify **common_roles** to pre-generate role arns for commonly used roles. This is helpful while creating cross-account user profiles.
+```
+roles = [
+    module.org.accounts["dev"].role["admin"]
+    module.org.accounts["sandbox"].role["developer"]
+    module.org.accounts["prod"].role["read-only"]
+]
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_account"></a> [iam\_account](#module\_iam\_account) | terraform-aws-modules/iam/aws//modules/iam-account | 5.46.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_organizations_account.account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_account) | resource |
+| [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_organization) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_advanced_common_roles"></a> [advanced\_common\_roles](#input\_advanced\_common\_roles) | List of roles that should be present in all accounts | `list(string)` | <pre>[<br/>  "admin",<br/>  "developer",<br/>  "read-only"<br/>]</pre> | no |
+| <a name="input_dangerous_close_on_deletion"></a> [dangerous\_close\_on\_deletion](#input\_dangerous\_close\_on\_deletion) | Close sub-acounts on deletion | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | The alias for the AWS account | `string` | n/a | yes |
+| <a name="input_sub_accounts"></a> [sub\_accounts](#input\_sub\_accounts) | A list of sub-accounts to create (name, email) | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_accounts"></a> [accounts](#output\_accounts) | Details of tha AWS accouns in the organization. [See readme] |
+<!-- END_TF_DOCS -->

--- a/modules/organization/iam.tf
+++ b/modules/organization/iam.tf
@@ -1,0 +1,18 @@
+module "iam_account" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-account"
+  version = "5.46.0"
+
+  account_alias = var.name
+
+  allow_users_to_change_password = true
+  create_account_password_policy = true
+  get_caller_identity            = true
+  max_password_age               = 90
+
+  minimum_password_length      = 20
+  password_reuse_prevention    = 4
+  require_lowercase_characters = true
+  require_numbers              = true
+  require_symbols              = true
+  require_uppercase_characters = true
+}

--- a/modules/organization/iam.tf
+++ b/modules/organization/iam.tf
@@ -1,6 +1,6 @@
 module "iam_account" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-account"
-  version = "5.46.0"
+  version = "~>5.46.0"
 
   account_alias = var.name
 

--- a/modules/organization/org.tf
+++ b/modules/organization/org.tf
@@ -1,0 +1,14 @@
+resource "aws_organizations_organization" "this" {
+  feature_set = "ALL"
+}
+
+resource "aws_organizations_account" "account" {
+  for_each = var.sub_accounts
+  name     = each.key
+  email    = each.value
+
+  close_on_deletion          = var.dangerous_close_on_deletion
+  iam_user_access_to_billing = "ALLOW"
+  role_name                  = "admin"
+}
+

--- a/modules/organization/outputs.tf
+++ b/modules/organization/outputs.tf
@@ -1,0 +1,14 @@
+locals {
+  main_account = { main = module.iam_account.caller_identity_account_id }
+  sub_accounts = { for name, email in var.sub_accounts : name => aws_organizations_account.account[name].id }
+  all_accounts = merge(local.main_account, local.sub_accounts)
+}
+
+output "accounts" {
+  description = "Details of tha AWS accouns in the organization. [See readme] "
+
+  value = { for name, id in local.all_accounts : name => {
+    id = id
+    role = { for name in var.advanced_common_roles : name => "arn:aws:iam::${id}:role/${name}" } }
+  }
+}

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -1,0 +1,32 @@
+variable "name" {
+  description = "The alias for the AWS account"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*$", var.name))
+    error_message = "The account alias must start with an alphanumeric character and only contain lowercase alphanumeric characters and hyphens"
+  }
+}
+
+variable "sub_accounts" {
+  description = "A list of sub-accounts to create (name, email)"
+  type        = map(string)
+
+  default = {}
+}
+
+
+
+variable "advanced_common_roles" {
+  description = "List of roles that should be present in all accounts"
+  type        = list(string)
+  default     = ["admin", "developer", "read-only"]
+}
+
+
+
+variable "dangerous_close_on_deletion" {
+  description = "Close sub-acounts on deletion"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
The module provides a basic organization setup. This includes:
* IAM Password policy for root account
* Create sub-accounts and expose them in a friendly manner that can be exposed from the workspace