### PR TITLE
Create IAM user module

### DIFF
--- a/modules/user/README.md
+++ b/modules/user/README.md
@@ -42,7 +42,7 @@ No modules.
 | [aws_iam_policy.cross_account_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_group_membership.groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
-| [aws_iam_user_policy_attachment.AdministratorAccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_policy_attachment.administrator_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.cross_account_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_ssh_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
 | [aws_iam_policy_document.cross_account_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -53,11 +53,11 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin"></a> [admin](#input\_admin) | Grant AdministratorAccess to the account | `bool` | `false` | no |
 | <a name="input_advanced_ssh_key_encoding"></a> [advanced\_ssh\_key\_encoding](#input\_advanced\_ssh\_key\_encoding) | Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM | `string` | `"SSH"` | no |
-| <a name="input_groups"></a> [groups](#input\_groups) | List of groups whuch will be attached to the user | `list` | `[]` | no |
+| <a name="input_groups"></a> [groups](#input\_groups) | List of group names whuch will be attached to the user | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Desired name for the IAM user | `string` | n/a | yes |
-| <a name="input_roles"></a> [roles](#input\_roles) | List of roles that the user will be granted AssumeRole permissions | `list` | `[]` | no |
+| <a name="input_roles"></a> [roles](#input\_roles) | List of role arns that the user will be granted AssumeRole permissions | `list(string)` | `[]` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | `string` | `null` | no |
-| <a name="input_username"></a> [username](#input\_username) | The username for the IAM user | `string` | `null` | no |
+| <a name="input_username"></a> [username](#input\_username) | The username for the IAM user (will be auto generated from name when not provided) | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/user/README.md
+++ b/modules/user/README.md
@@ -1,0 +1,65 @@
+# AWS IAM User creation
+
+This module will create user on IAM account and allow them to assume certain roles on sub-accounts.
+Check out scripts directory for tools to create user login profile.
+
+
+## Example usage:
+```
+module "iam_user_john_doe" {
+  source = "module/user"
+  name   = "John Doe"
+  admin  = false
+
+  roles = [
+    module.org.accounts["dev"].role["admin"]
+    module.org.accounts["int"].role["developer"]
+    module.org.accounts["prod"].role["read-only"]
+  ]
+}
+```
+
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.cross_account_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_group_membership.groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
+| [aws_iam_user_policy_attachment.AdministratorAccess](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_policy_attachment.cross_account_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_ssh_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
+| [aws_iam_policy_document.cross_account_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin"></a> [admin](#input\_admin) | Grant AdministratorAccess to the account | `bool` | `false` | no |
+| <a name="input_advanced_ssh_key_encoding"></a> [advanced\_ssh\_key\_encoding](#input\_advanced\_ssh\_key\_encoding) | Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM | `string` | `"SSH"` | no |
+| <a name="input_groups"></a> [groups](#input\_groups) | List of groups whuch will be attached to the user | `list` | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | Desired name for the IAM user | `string` | n/a | yes |
+| <a name="input_roles"></a> [roles](#input\_roles) | List of roles that the user will be granted AssumeRole permissions | `list` | `[]` | no |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The SSH public key. The public key must be encoded in ssh-rsa format or PEM format | `string` | `null` | no |
+| <a name="input_username"></a> [username](#input\_username) | The username for the IAM user | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/user/main.tf
+++ b/modules/user/main.tf
@@ -19,7 +19,7 @@ resource "aws_iam_user_ssh_key" "this" {
   public_key = var.ssh_public_key
 }
 
-resource "aws_iam_user_policy_attachment" "AdministratorAccess" {
+resource "aws_iam_user_policy_attachment" "administrator_access" {
   count      = var.admin ? 1 : 0
   user       = aws_iam_user.this.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"

--- a/modules/user/main.tf
+++ b/modules/user/main.tf
@@ -1,0 +1,33 @@
+locals {
+  auto_username = replace(lower(var.name), "/[^a-z]/", ".")
+}
+
+resource "aws_iam_user" "this" {
+  name          = var.username != null ? var.username : local.auto_username
+  path          = "/users/"
+  force_destroy = true
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_iam_user_ssh_key" "this" {
+  count = var.ssh_public_key != null ? 1 : 0
+
+  username   = aws_iam_user.this.name
+  encoding   = var.advanced_ssh_key_encoding
+  public_key = var.ssh_public_key
+}
+
+resource "aws_iam_user_policy_attachment" "AdministratorAccess" {
+  count      = var.admin ? 1 : 0
+  user       = aws_iam_user.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+
+resource "aws_iam_user_group_membership" "groups" {
+  user = aws_iam_user.this.name
+
+  groups = var.groups
+}

--- a/modules/user/roles.tf
+++ b/modules/user/roles.tf
@@ -1,0 +1,17 @@
+data "aws_iam_policy_document" "cross_account_roles" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = var.roles
+  }
+}
+
+resource "aws_iam_policy" "cross_account_roles" {
+  name        = "CrossAccountRoles-${aws_iam_user.this.name}"
+  description = "CrossAccountRoles policy for ${aws_iam_user.this.name}"
+  policy      = data.aws_iam_policy_document.cross_account_roles.json
+}
+
+resource "aws_iam_user_policy_attachment" "cross_account_roles" {
+  user       = aws_iam_user.this.name
+  policy_arn = aws_iam_policy.cross_account_roles.arn
+}

--- a/modules/user/variables.tf
+++ b/modules/user/variables.tf
@@ -4,7 +4,7 @@ variable "name" {
 }
 
 variable "username" {
-  description = "The username for the IAM user (will be auto generated from name)"
+  description = "The username for the IAM user (will be auto generated from name when not provided)"
   type        = string
   default     = null
 }
@@ -23,15 +23,18 @@ variable "ssh_public_key" {
 
 variable "admin" {
   description = "Grant AdministratorAccess to the account"
+  type        = bool
   default     = false
 }
 
 variable "roles" {
-  description = "List of roles that the user will be granted AssumeRole permissions"
+  description = "List of role arns that the user will be granted AssumeRole permissions"
+  type        = list(string)
   default     = []
 }
 
 variable "groups" {
-  description = "List of groups whuch will be attached to the user"
+  description = "List of group names whuch will be attached to the user"
+  type        = list(string)
   default     = []
 }

--- a/modules/user/variables.tf
+++ b/modules/user/variables.tf
@@ -1,0 +1,37 @@
+variable "name" {
+  description = "Desired name for the IAM user"
+  type        = string
+}
+
+variable "username" {
+  description = "The username for the IAM user (will be auto generated from name)"
+  type        = string
+  default     = null
+}
+
+variable "advanced_ssh_key_encoding" {
+  description = "Specifies the public key encoding format to use in the response. To retrieve the public key in ssh-rsa format, use SSH. To retrieve the public key in PEM format, use PEM"
+  type        = string
+  default     = "SSH"
+}
+
+variable "ssh_public_key" {
+  description = "The SSH public key. The public key must be encoded in ssh-rsa format or PEM format"
+  type        = string
+  default     = null
+}
+
+variable "admin" {
+  description = "Grant AdministratorAccess to the account"
+  default     = false
+}
+
+variable "roles" {
+  description = "List of roles that the user will be granted AssumeRole permissions"
+  default     = []
+}
+
+variable "groups" {
+  description = "List of groups whuch will be attached to the user"
+  default     = []
+}


### PR DESCRIPTION
The user module creates a "user shell" with basic access to the user's IAM account and cross-account role permissions.